### PR TITLE
Fixed listing fonts with spaces in filenames

### DIFF
--- a/fnt
+++ b/fnt
@@ -71,7 +71,7 @@ case $1 in
 		# macOS mainly comes with *.ttc (truetype font collections, that can not be processed by otfinfo)
 		#ls -1 /System/Library/Fonts/*.?tf /usr/share/fonts/*type/*/*.?tf $HOME/Library/Fonts/*.?tf $HOME/.fonts/*.?tf 2>/dev/null | while read f; do
 		ls -1 $HOME/Library/Fonts/*.?tf $HOME/.fonts/*.?tf 2>/dev/null | while read f; do
-			echo "$f [$(otfinfo -u ""$f"" 2>/dev/null|wc -l|awk '{print $1}')]" | sed s,.*/,,
+			echo $f [$(otfinfo -u "$f" 2>/dev/null|wc -l|awk '{print $1}')] | sed s,.*/,,
 		done
 	;;
 


### PR DESCRIPTION
I fixed the bug you mentioned in issue #3.