### PR TITLE
Catch error if Packages.xz is not downloaded

### DIFF
--- a/fnt
+++ b/fnt
@@ -84,6 +84,13 @@ case $1 in
 	;;
 
 	install|-i)
+
+		if [ ! -f $HOME/.fnt/Packages.xz ]; then
+			echo "Could not find $HOME/.fnt/Packages.xz"
+			echo "Please run $0 update"
+			exit 1
+		fi
+
 		# cat $HOME/.fnt/Packages.xz |unxz|grep "^Package:\|^Homepage:\|^Size:\|^Installed-Size:\|^Description:"
 		# cat $HOME/.fnt/Packages.xz |unxz| awk '!NF{print line; line=""}{line=line " " $0}' |grep "Package: fonts-"
 		p=$(cat $HOME/.fnt/Packages.xz |unxz| grep -v "^Architecture:\|^Section:\|^Priority:\|^Replaces:\|^Provides:\|^Brekas:\|^Maintainer:\|^MD5sum:\|^Source:\|^Breaks:\|^Multi-Arch:\|^Description-\|^Tag:\|^SHA256:"|awk '!NF{print line; line=""}{line=line " " $0}' |grep "Package: fonts-"|grep fonts-$2|head -1)

--- a/fnt
+++ b/fnt
@@ -84,9 +84,8 @@ case $1 in
 	;;
 
 	install|-i)
-
-		if [ ! -f $HOME/.fnt/Packages.xz ]; then
-			echo "Could not find $HOME/.fnt/Packages.xz"
+		if [ ! -f ${TMPDIR}/Packages.xz ]; then
+			echo "Could not find ${TMPDIR}/Packages.xz"
 			echo "Please run $0 update"
 			exit 1
 		fi


### PR DESCRIPTION
Prints informative error message if user has not run fnt update yet, and aborts early.

I got a bit tripped up when I tried running it for the first time, and didn't see that I had to do ```./fnt update``` first, in the README.md

```

./fnt install
cat: /Users/tim/.fnt/Packages.xz: No such file or directory
unxz: (stdin): File format not recognized
awk: trying to access out of range field -2
 input record number 1, file 
 source line number 1
basename: missing operand
Try 'basename --help' for more information.
Installing fonts-  [ 000 http://ftp.ch.debian.org/debian/]...
usage:  ar -d [-TLsv] archive file ...
	ar -m [-TLsv] archive file ...
	ar -m [-abiTLsv] position archive file ...
	ar -p [-TLsv] archive [file ...]
	ar -q [-cTLsv] archive file ...
	ar -r [-cuTLsv] archive file ...
	ar -r [-abciuTLsv] position archive file ...
	ar -t [-TLsv] archive [file ...]
	ar -x [-ouTLsv] archive [file ...]
tar: Error opening archive: Failed to open 'data.tar.xz'
rm: cannot remove 'control.tar*': No such file or directory
rm: cannot remove 'data.tar*': No such file or directory
rm: cannot remove 'debian-binary': No such file or directory


```
