### PR TITLE
On Linux, install fonts in ~/.local/share/fonts

### DIFF
--- a/fnt
+++ b/fnt
@@ -33,7 +33,7 @@ case "$s" in
 		check="curl chafa otfinfo"
 		i="apt"
 		md5="md5sum"
-		target="$HOME/.fonts/"
+		target="$HOME/.local/share/fonts/"
 		if [ 0 -eq `id -u` ]; then
         		target="/usr/local/share/fonts/"
 			mkdir -p $target
@@ -103,8 +103,8 @@ case "$1" in
 	list|-l)
 		# echo Listing...
 		# macOS mainly comes with *.ttc (truetype font collections, that can not be processed by otfinfo)
-		#ls -1 /System/Library/Fonts/*.?tf /usr/share/fonts/*type/*/*.?tf $HOME/Library/Fonts/*.?tf $HOME/.fonts/*.?tf 2>/dev/null | while read f; do
-		ls -1 $HOME/Library/Fonts/*.?tf $HOME/.fonts/*.?tf /usr/local/share/fonts/*.?tf 2>/dev/null | while read f; do
+		#ls -1 /System/Library/Fonts/*.?tf /usr/share/fonts/*type/*/*.?tf $HOME/Library/Fonts/*.?tf $HOME/.local/share/fonts $HOME/.fonts/*.?tf 2>/dev/null | while read f; do
+		ls -1 $HOME/Library/Fonts/*.?tf $HOME/.local/share/fonts/*.?tf $HOME/.fonts/*.?tf /usr/local/share/fonts/*.?tf 2>/dev/null | while read f; do
 			echo "$f" [$(otfinfo -u "$f" 2>/dev/null|wc -l|awk '{print $1}')] | sed s,.*/,,
 		done
 	;;


### PR DESCRIPTION
Use of `~/.fonts` is deprecated and may not even work on some distributions (for example NixOS), see `/etc/fonts/fonts.conf` on a Debian system:

```xml
<!-- Font directory list -->

        <dir>/usr/share/fonts</dir>
        <dir>/usr/local/share/fonts</dir>
        <dir prefix="xdg">fonts</dir>
        <!-- the following element will be removed in the future -->
        <dir>~/.fonts</dir>
```