### PR TITLE
fnt: catch package-duplicates (fonts-wine)

### DIFF
--- a/fnt
+++ b/fnt
@@ -103,7 +103,7 @@ deb_handler() {
 	PIT="${TMPDIR}/extract"
 	mkdir -m go-rwx "$PIT" || { echo "Couldn't eat tartar." ; exit 73 ; }
 	NAME="$1"
-	INFOS="$(unxz -c "$PACKAGES" | awk "/^Package: ${NAME}$/,/^$/" | awk '/^(Version|Installed-Size|Filename|Size|MD5sum): /')"
+	INFOS="$(unxz -c "$PACKAGES" | sed -n '/^Package: '"$NAME"'$/,/^$/ {H}; /^Package: '"$NAME"'$/ h; $ {g;p}' | awk '/^(Version|Installed-Size|Filename|Size|MD5sum): /')"
 	VER="$(awk '/^Version: /{print$2}' <<< "$INFOS")"
 	INSTSIZE="$(awk '/^Installed-Size: /{print$2}' <<< "$INFOS")"
 	DOWNSIZE="$(awk '/^Size: /{print$2}' <<< "$INFOS")"


### PR DESCRIPTION
because fonts-wine sucks
```sh
% curl https://deb.debian.org/debian/dists/sid/main/binary-all/Packages.xz | unxz |awk '/^Package: fonts-wine/,/^$/'
Package: fonts-wine
Source: wine
Version: 9.0~repack-7
Installed-Size: 995
Maintainer: Debian Wine Party <debian-wine@lists.debian.org>
Architecture: all
Description: Windows API implementation - fonts
Multi-Arch: foreign
Homepage: https://www.winehq.org
Description-md5: 654455ac5045b1d7aa5283d7123e37dd
Section: fonts
Priority: optional
Filename: pool/main/w/wine/fonts-wine_9.0~repack-7_all.deb
Size: 192988
MD5sum: 740e0f66e603d1fdb0a1b53d4c2057d1
SHA256: 0c186b6154910bb1f650d3b23df939f696825890c1be57b55b1be9b6598f1687

Package: fonts-wine
Source: wine
Version: 10.0~rc2~repack-2
Installed-Size: 993
Maintainer: Debian Wine Party <debian-wine@lists.debian.org>
Architecture: all
Description: Windows API implementation - fonts
Multi-Arch: foreign
Homepage: https://www.winehq.org
Description-md5: 654455ac5045b1d7aa5283d7123e37dd
Section: fonts
Priority: optional
Filename: pool/main/w/wine/fonts-wine_10.0~rc2~repack-2_all.deb
Size: 191560
MD5sum: 1ee39dc04187afa103adf3ec7d0c5f3a
SHA256: eeaca86bc546440628e6baeafeac98ac3cb9dd8ca2b9158460970a5997a6e0bf

```