### PR TITLE
fnt: fix handling of space-delimited files

### DIFF
--- a/fnt
+++ b/fnt
@@ -127,7 +127,7 @@ deb_handler() {
 		ar x "${TMPDIR}/$FNAME" "$CONTROL"
 		tar xf "${PIT}/control/${CONTROL}"
 		sed -n 's/^\(.*\) .*\/\(.*tf$\)/\1 \2/p' "${PIT}/control/md5sums" > "$FNTINDEXDIR/$NAME"
-		awk -v pkg="$NAME" '{printf "Package: %s File: %s\n", pkg, $2}' "$FNTINDEXDIR/$NAME"
+		awk -v pkg="$NAME" '$1="";{printf "Package: %s File:%s\n", pkg, $NFR}' "$FNTINDEXDIR/$NAME"
 	else
 		echo "Can't verify md5sum!"
 		exit 65
@@ -365,8 +365,9 @@ EOF
 		fi
 		if [ $# -eq 2 ] && [ -r "$FNTINDEXDIR/$2" ]; then
 			# shellcheck disable=SC2046
-			find $(awk -v target="$TARGET" \
-				'{printf "%s/%s ", target, $2}' "$FNTINDEXDIR/$2") |
+			awk -v target="$TARGET" wk -v target="$TARGET" \
+				'$1="";{printf "%s/%s\n", target, substr($0,2)}' \
+				"$FNTINDEXDIR/$2" |
 				while read -r font; do
 					echo "$(basename "${font}") [$(otfinfo -u "$font" 2>/dev/null | wc -l)]"
 				done


### PR DESCRIPTION
 * e.g. fnt install fonts-courier-prime
 
```sh
% fnt install fonts-courier-prime
Installing fonts-courier-prime 0+git20190115-4 [112388 459000 https://deb.debian.org/debian/pool/main/f/fonts-courier-prime/fonts-courier-prime_0+git20190115-4_all.deb]...
Package: fonts-courier-prime File: Courier Prime Bold Italic.otf
Package: fonts-courier-prime File: Courier Prime Bold.otf
Package: fonts-courier-prime File: Courier Prime Code Italic.otf
Package: fonts-courier-prime File: Courier Prime Code.otf
Package: fonts-courier-prime File: Courier Prime Italic.otf
Package: fonts-courier-prime File: Courier Prime Sans Bold Italic.otf
Package: fonts-courier-prime File: Courier Prime Sans Bold.otf
Package: fonts-courier-prime File: Courier Prime Sans Italic.otf
Package: fonts-courier-prime File: Courier Prime Sans.otf
Package: fonts-courier-prime File: Courier Prime.otf
```